### PR TITLE
Don't throw exception when viewing empty tag.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,8 +3,6 @@ class PostsController < ApplicationController
     @tag = params[:tag]
     @posts = Post.find_recent(:tag => @tag, :include => :tags)
 
-    raise(ActiveRecord::RecordNotFound) if @tag && @posts.empty?
-
     respond_to do |format|
       format.html
       format.atom { render :layout => false }


### PR DESCRIPTION
Hey, I know you're away. Don't worry. This will wait for you.

Pull request description:

I'm settings my posts date to future as a replacement for the missing "draft" feature. If you do so the post will not be displayed in posts index or posts index by tag, but the tag will be visible in the navigation bar. Clicking a new for which the article isn't published yet causes an exception.

This commits makes it display "There are no posts yet".

The real fix to this problem would be filtering out tags with only unpublished posts, but this would either require a lot more coding or would slow down tag list terribly.
