### PR TITLE
Fix time shifts

### DIFF
--- a/config/initializers/set_chronic_timezone.rb
+++ b/config/initializers/set_chronic_timezone.rb
@@ -1,0 +1,1 @@
+Chronic.time_class = Time.zone


### PR DESCRIPTION
If system's time zone != rails time zone (default utc) then continuously saving a post shifts it's creation time by the time zone difference.

This initializes Chronic timezone to Rails config.
