### PR TITLE
fix in spec

### DIFF
--- a/spec/controllers/pages_routing_spec.rb
+++ b/spec/controllers/pages_routing_spec.rb
@@ -2,11 +2,6 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe PagesController do
   describe "route" do
-    it "should not route /pages to show" do
-      pending("This assertion fails under 1.9.2, but not under 1.8.7. No idea why.")
-      {:get => "/pages"}.should_not route_to(:controller => 'pages', :action => 'show')
-    end
-
     it "should recognise show with id" do
       {:get => "/pages/my-page"}.should route_to(:controller => 'pages', :action => 'show', :id => 'my-page')
     end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -160,5 +160,9 @@ describe PostsController do
       do_get
       assigns[:comment].should equal(@comment)
     end
+    
+    it "should route /pages to posts#index with tag pages" do
+      {:get => "/pages"}.should route_to(:controller => 'posts', :action => 'index', :tag => 'pages')
+    end
   end
 end


### PR DESCRIPTION
For negative tests, only the route recognition failure can be tested; since route generation via path_to() will always generate a path as requested. Use .should_not be_routable() in this case

http://rspec.rubyforge.org/rspec-rails/1.2.9/classes/Spec/Rails/Matchers.html#M000030
