### PR TITLE
Delete the implicit content type header assignment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  after_filter :set_content_type
 
   protected
-
-  def set_content_type
-    headers['Content-Type'] ||= 'text/html; charset=utf-8'
-  end
 
   def enki_config
     @@enki_config = Enki::Config.default


### PR DESCRIPTION
I don't know what was the reason for this, but Rails knows better what the response content type really is.

@ErwinM has messaged me to complain that both:

```
render :js => "alert('AHAHAHAHA');"
```

and

```
render :js => "alert('AHAHAHAHA');", :content_type => 'text/javascript'
```

commands were sending data with content type "text/html". This patch reverts enki to default rails behavior.
