### PR TITLE
add #content padding-bottom

### DIFF
--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -303,3 +303,7 @@ table img {
 #preview .content table {
   margin-bottom: 0;
 }
+
+#content {
+  padding-bottom: 2em;
+}


### PR DESCRIPTION
After clicking update/create post, the update button is not longer clickable. The MessageLog div overlaps it.

This fix adds some space between the update button and the bottom of the page in admin so that MessageLog doesn't  overlap the button.
