### PR TITLE
Fix links with #comments fragment by adding id to post page

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
 
 <%= render @post %>
 
-<ol class="commentlist">
+<ol id="comments" class="commentlist">
   <% @post.approved_comments.each do |comment| -%>
     <li<%=raw cycle(' class="alt"', '') %> id="comment-<%= comment.id %>">
       <%= render comment %>


### PR DESCRIPTION
The hyperlinks to a permalink URL with a "comments" fragment don't
work: there is no "comments" fragment on the post page to target.

Add a "comments" id attribute to the list of comments, which renders
even when the list is empty.
