### PR TITLE
Track db/schema.rb in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ log
 tmp/**/*
 tmp
 config/database.yml
-db/schema.rb
 .bundle
 *.log

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,109 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended to check this file into your version control system.
+
+ActiveRecord::Schema.define(:version => 20110709024316) do
+
+  create_table "comments", :force => true do |t|
+    t.integer  "post_id",      :null => false
+    t.string   "author",       :null => false
+    t.string   "author_url",   :null => false
+    t.string   "author_email", :null => false
+    t.text     "body",         :null => false
+    t.text     "body_html",    :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "comments", ["created_at"], :name => "index_comments_on_created_at"
+  add_index "comments", ["post_id"], :name => "index_comments_on_post_id"
+
+  create_table "open_id_authentication_associations", :force => true do |t|
+    t.integer "issued"
+    t.integer "lifetime"
+    t.string  "handle"
+    t.string  "assoc_type"
+    t.binary  "server_url"
+    t.binary  "secret"
+  end
+
+  create_table "open_id_authentication_nonces", :force => true do |t|
+    t.integer "timestamp",  :null => false
+    t.string  "server_url"
+    t.string  "salt",       :null => false
+  end
+
+  create_table "pages", :force => true do |t|
+    t.string   "title",      :null => false
+    t.string   "slug",       :null => false
+    t.text     "body",       :null => false
+    t.text     "body_html",  :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "pages", ["created_at"], :name => "index_pages_on_created_at"
+  add_index "pages", ["slug"], :name => "pages_slug_unique_idx"
+  add_index "pages", ["title"], :name => "index_pages_on_title"
+
+  create_table "posts", :force => true do |t|
+    t.string   "title",                                     :null => false
+    t.string   "slug",                                      :null => false
+    t.text     "body",                                      :null => false
+    t.text     "body_html",                                 :null => false
+    t.boolean  "active",                  :default => true, :null => false
+    t.integer  "approved_comments_count", :default => 0,    :null => false
+    t.string   "cached_tag_list"
+    t.datetime "published_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "edited_at",                                 :null => false
+  end
+
+  add_index "posts", ["published_at"], :name => "index_posts_on_published_at"
+  add_index "posts", ["slug"], :name => "altered_posts_slug_unique_idx"
+
+  create_table "sessions", :force => true do |t|
+    t.string   "session_id", :null => false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
+  add_index "sessions", ["updated_at"], :name => "index_sessions_on_updated_at"
+
+  create_table "taggings", :force => true do |t|
+    t.integer  "tag_id"
+    t.integer  "taggable_id"
+    t.datetime "created_at"
+  end
+
+  add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
+  add_index "taggings", ["taggable_id"], :name => "index_taggings_on_taggable_id_and_taggable_type"
+
+  create_table "tags", :force => true do |t|
+    t.string  "name"
+    t.integer "taggings_count", :default => 0, :null => false
+  end
+
+  add_index "tags", ["name"], :name => "index_tags_on_name"
+
+  create_table "undo_items", :force => true do |t|
+    t.string   "type",       :null => false
+    t.datetime "created_at", :null => false
+    t.text     "data"
+  end
+
+  add_index "undo_items", ["created_at"], :name => "index_undo_items_on_created_at"
+
+end


### PR DESCRIPTION
Rails best practice is to track db/schema.rb in version control, but
Enki does not track it.  Generally, version control best practices
dictate that generated files are not tracked, and db/schema.rb is
a generated file in some sense.  But the default Rails .gitignore does
not exclude it because:

```
Migrations, mighty as they may be, are not the authoritative source
for your database schema. That role falls to either db/schema.rb or
an SQL file which Active Record generates...
http://guides.rubyonrails.org/migrations.html#what-are-schema-files-for
```

Remove db/schema.rb from .gitignore and add it to Git version control.
This version of db/schema.rb was generated by running the current set of
migrations (which also regenerates db/schema.rb).

---

Xavier,

It seems that Enki does not track db/schema.rb.  My impression is that the Rails 3 best practice is to track it.  If you prefer not to, I'm curious to learn why.  I don't have a very strong preference for what Enki core does, but here's a pull request in case you see fit to track it.

I noticed the absence of schema.rb in the process of creating a feature branch that makes a schema change.  I'm accustomed to seeing the change to schema.rb in the diff.  I'd like to figure out whether that feature branch should contain changes to schema.rb before I publish it.

Marcel
