### PR TITLE
Add body_filter to Post to allow authoring in HTML

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -100,7 +100,14 @@ class Post < ActiveRecord::Base
   end
 
   def apply_filter
-    self.body_html = EnkiFormatter.format_as_xhtml(self.body)
+    case body_filter.to_s
+    when 'none' then
+      self.body_html = self.body
+    when 'lesstile_to_xhtml' then
+      self.body_html = EnkiFormatter.format_as_xhtml(self.body)
+    else
+      raise "Unknown filter type: #{body_filter}"
+    end
   end
 
   def set_dates

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -1,6 +1,7 @@
 <%= form.inputs do -%>
   <%= form.input :title -%>
   <%= form.input :body, :hint => "<a href='http://textile.thresholdstate.com/'>Textile enabled</a>. Use Ctrl+E to switch between preview and edit mode.".html_safe -%>
+  <%= form.input :body_filter, :as => 'select', :collection => { "Textile to XHTML" => :lesstile_to_xhtml, "None (author in HTML)" => :none }, :include_blank => false, :hint => '' -%>
   <%= form.input :tag_list, :as => 'string', :required => false, :hint => 'Comma separated: ruby, rails&hellip;'.html_safe -%>
 <% end -%>
 <%= form.inputs do -%>

--- a/db/migrate/20130318145757_add_body_filter_to_post.rb
+++ b/db/migrate/20130318145757_add_body_filter_to_post.rb
@@ -1,0 +1,5 @@
+class AddBodyFilterToPost < ActiveRecord::Migration
+  def change
+    add_column :posts, :body_filter, :string, :default => 'lesstile_to_xhtml'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110709024316) do
+ActiveRecord::Schema.define(:version => 20130318145757) do
 
   create_table "comments", :force => true do |t|
     t.integer  "post_id",      :null => false
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(:version => 20110709024316) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "edited_at",                                 :null => false
+    t.string   "body_filter",             :default => "lesstile_to_xhtml"
   end
 
   add_index "posts", ["published_at"], :name => "index_posts_on_published_at"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -243,3 +243,16 @@ describe Post, '.build_for_preview' do
     @post.tags.collect {|tag| tag.name}.should == ['ruby']
   end
 end
+
+describe Post, "#apply_filter" do
+  it "converts Textile to HTML by default" do
+    post = Post.new(:body => "* Hello")
+    post.apply_filter
+    post.body_html.should include("<li>Hello</li>")
+  end
+  it "does not filter body when body_filter is 'none'" do
+    post = Post.new(:body => "<p>Hello\nWorld</p>", :body_filter => :none)
+    post.apply_filter
+    post.body_html.should == "<p>Hello\nWorld</p>"
+  end
+end


### PR DESCRIPTION
I have some old posts that I authored in HTML, and I anticipate
continuing to do so on occasion.  At a minimum, I need to be able to
preserve the markup of the posts I import into Enki Blog.  Ideally, I'd
also be able to easily use HTML to author posts in the future.
(Embedding tags in Textile is not enough.)

Add a body_filter attribute to the Post model.  Adjust apply_filter to
be able to handle the default textile-to-XHTML converstion or a null
conversion that assumes the post was authored as HTML already.

---

Again, not sure if this fits within your vision for Enki core... 
