### PR TITLE
Removed superfluous equals signs from ERB syntax.

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
   <cite><%= author_link(comment) %></cite> says:
   <br/>
   <small class="commentmetadata"><a href="#comment-<%= comment.id %>" title=""><%= format_comment_date(comment.created_at) %></a></small>
-  <p><%== comment.body_html %></p>
+  <p><%= comment.body_html %></p>

--- a/app/views/pages/_page.html.erb
+++ b/app/views/pages/_page.html.erb
@@ -1,1 +1,1 @@
-<%== page.body_html %>
+<%= page.body_html %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,7 @@
 <h2><%= link_to_post(post) %></h2>
 
 <div class="entry-body">
-  <%== post.body_html %>
+  <%= post.body_html %>
 </div>
 <div class="meta">
   <ul>


### PR DESCRIPTION
Doing some clean up of my own Enki repo lately, noticed this little bit of house keeping that could be contributed back.
