### PR TITLE
Fix addressing the issue where HTML is too eagerly escaped with relation to comments, pages and posts.

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
   <cite><%= author_link(comment) %></cite> says:
   <br/>
   <small class="commentmetadata"><a href="#comment-<%= comment.id %>" title=""><%= format_comment_date(comment.created_at) %></a></small>
-  <p><%= comment.body_html %></p>
+  <p><%= raw(comment.body_html) %></p>

--- a/app/views/pages/_page.html.erb
+++ b/app/views/pages/_page.html.erb
@@ -1,1 +1,1 @@
-<%= page.body_html %>
+<%= raw(page.body_html) %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,7 @@
 <h2><%= link_to_post(post) %></h2>
 
 <div class="entry-body">
-  <%= post.body_html %>
+  <%= raw(post.body_html) %>
 </div>
 <div class="meta">
   <ul>


### PR DESCRIPTION
Addressing mcary's comments on my breaking change in pull request #77. Sorry guys, my bad. I wil never again forget that <%== is the same as using the raw helper, but for those developers in the future who are as I was, I've opted to go with explicitly calling raw here.
