### PR TITLE
Changed SQL function call ifnull() to coalesce().

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -5,7 +5,7 @@ class Admin::PostsController < Admin::BaseController
     respond_to do |format|
       format.html {
         @posts = Post.paginate(
-          :order => "ifnull(published_at, updated_at) DESC",
+          :order => "coalesce(published_at, updated_at) DESC",
           :page  => params[:page]
         )
       }


### PR DESCRIPTION
The SQL function ifnull() is not recognised by PostgreSQL and
causes an error when Enki is used with PostgreSQL as the backend
data store. Changing the call to coalesce() seems to work for
both MySQL and PostgreSQL.
