### PR TITLE
Applied fix for logging in via OpenID to the admin area.

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,4 +1,7 @@
 class Admin::SessionsController < ApplicationController
+  skip_before_filter :verify_authenticity_token, :only => :create
+  before_filter :verify_authenticity_token_unless_openid, :only => :create
+
   layout 'login'
 
   def show
@@ -49,5 +52,10 @@ protected
   def allow_login_bypass?
     %w(development test).include?(Rails.env)
   end
+
+  def verify_authenticity_token_unless_openid
+    verify_authenticity_token unless using_open_id?
+  end
+
   helper_method :allow_login_bypass?
 end


### PR DESCRIPTION
Rails now contains code that resets the session if the CSRF request
forgery check fails. This was happening on the OpenID callback when
logging in to the Enki admin area, which broke OpenID login.

This commit disables the CSRF check only for OpenID callbacks when
logging in to the Enki admin area.

Fixes #91.
