### PR TITLE
Fixed post preview feature.

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -56,7 +56,7 @@ class Admin::PostsController < Admin::BaseController
   end
 
   def preview
-    @post = Post.build_for_preview(params[:post])
+    @post = Post.build_for_preview(post_params)
 
     respond_to do |format|
       format.js {

--- a/spec/controllers/admin/posts_controller_spec.rb
+++ b/spec/controllers/admin/posts_controller_spec.rb
@@ -218,17 +218,19 @@ end
 
 describe Admin::PostsController, 'with an AJAX request to preview' do
   before(:each) do
-    Post.should_receive(:build_for_preview).and_return(@post = mock_model(Post))
     session[:logged_in] = true
     xhr :post, :preview, :post => {
-      :title        => 'My Post',
-      :body         => 'body',
-      :tag_list     => 'ruby',
-      :published_at => 'now'
+      :title                => 'My Post',
+      :body                 => 'body',
+      :tag_list             => 'ruby',
+      :published_at_natural => 'now'
     }
   end
 
   it "assigns a new post for the view" do
-    assigns(:post).should == @post
+    assigns(:post).title.should == 'My Post'
+    assigns(:post).body.should == 'body'
+    assigns(:post).tag_list.should == ['ruby']
+    assigns(:post).published_at_natural.should == 'now'
   end
 end


### PR DESCRIPTION
The posts preview feature was broken by the advent of Rails 4 strong
params. This commit restores the feature back to working order.

Updated specs.
